### PR TITLE
feat(ci): add Docs Drift Check — detect AnalysisRule interface drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,30 @@ jobs:
       - name: Test
         run: go test ./...
 
+  check-docs:
+    name: Docs Drift Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check CONTRIBUTING.md documents all AnalysisRule methods
+        run: |
+          # Extract public method names from internal/rule/interface.go.
+          # Matches tab-indented lines starting with a capital letter followed by '('.
+          # If the interface grows (e.g. a new Validate() method), this check
+          # automatically fails until CONTRIBUTING.md is updated to document it.
+          FAILED=0
+          while IFS= read -r method; do
+            if ! grep -q "$method" CONTRIBUTING.md; then
+              echo "FAIL: '$method()' is defined in internal/rule/interface.go but missing from CONTRIBUTING.md"
+              FAILED=1
+            else
+              echo "OK:   '$method()' is documented in CONTRIBUTING.md"
+            fi
+          done < <(grep -v "^[[:space:]]*//" internal/rule/interface.go \
+                   | awk '/^[[:space:]]+[A-Z]/{gsub(/\(.*/, "", $1); print $1}')
+          exit $FAILED
+
   frontend:
     name: Frontend Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a `check-docs` job to CI that automatically detects when `internal/rule/interface.go` gains a new method that isn't documented in `CONTRIBUTING.md`.

**How it works:**
1. Parses `internal/rule/interface.go` with `awk` to extract public method names (capital-letter-prefixed)
2. For each method, greps `CONTRIBUTING.md` — fails if any are missing
3. Self-maintaining: no hardcoded method names, picks up new methods automatically

**Current output (passing):**
```
OK:   'Name()' is documented in CONTRIBUTING.md
OK:   'RequiredIndicators()' is documented in CONTRIBUTING.md
OK:   'Analyze()' is documented in CONTRIBUTING.md
```

**If interface gains `Validate()` without updating docs:**
```
FAIL: 'Validate()' is defined in internal/rule/interface.go but missing from CONTRIBUTING.md
```

## Why

The `rule.Rule` → `rule.AnalysisRule` interface name bug in CONTRIBUTING.md was only caught manually. This job prevents the same class of drift from recurring — it's the automated guard for the fix shipped in Phase 1.

Closes the TODOS.md item: `CI: CONTRIBUTING.md interface drift check`

## Test plan

- [x] `go test ./...` passes locally
- [x] Local simulation: all 3 methods pass
- [x] Local simulation: adding a fake 4th method causes exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)