### PR TITLE
feat(ci): add Docs Drift Check job to detect AnalysisRule interface d…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,30 @@ jobs:
       - name: Test
         run: go test ./...
 
+  check-docs:
+    name: Docs Drift Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check CONTRIBUTING.md documents all AnalysisRule methods
+        run: |
+          # Extract public method names from internal/rule/interface.go.
+          # Matches tab-indented lines starting with a capital letter followed by '('.
+          # If the interface grows (e.g. a new Validate() method), this check
+          # automatically fails until CONTRIBUTING.md is updated to document it.
+          FAILED=0
+          while IFS= read -r method; do
+            if ! grep -q "$method" CONTRIBUTING.md; then
+              echo "FAIL: '$method()' is defined in internal/rule/interface.go but missing from CONTRIBUTING.md"
+              FAILED=1
+            else
+              echo "OK:   '$method()' is documented in CONTRIBUTING.md"
+            fi
+          done < <(grep -v "^[[:space:]]*//" internal/rule/interface.go \
+                   | awk '/^[[:space:]]+[A-Z]/{gsub(/\(.*/, "", $1); print $1}')
+          exit $FAILED
+
   frontend:
     name: Frontend Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
…rift

Adds a check-docs job that extracts public method names from internal/rule/interface.go and verifies each one is documented in CONTRIBUTING.md.

If the interface ever gains a new method (e.g. Validate()), CI fails immediately — preventing silent documentation drift that breaks new contributors' first experience.

Uses awk to parse the interface so the check is self-maintaining: no hardcoded method names, no manual updates needed.

## Summary

<!-- Briefly describe what this PR does. -->

## Checklist

**If this PR adds a new trading rule:**

- [ ] `internal/methodology/<category>/<rule_name>.go` created
- [ ] `var _ rule.AnalysisRule = (*MyRule)(nil)` compile-time assertion included
- [ ] Rule registered in `config/rules.yaml`
- [ ] `_test.go` with table-driven tests (at minimum: signal fires, signal does not fire, too few bars)

**All PRs:**

- [ ] `go test ./...` passes locally
- [ ] `go vet ./...` produces no warnings
- [ ] `CHANGELOG.md` updated
- [ ] No `.env` file or real API keys in the diff

<!-- Items that don't apply to your PR can be marked N/A. -->
