### PR TITLE
fix(ui): Execution tab black screen when symbol_map is missing

### DIFF
--- a/web/src/GlobalConfigForm.tsx
+++ b/web/src/GlobalConfigForm.tsx
@@ -15,10 +15,11 @@ type Props = {
 
 type Row = { symbol: string; map: { broker: string; ticker: string }[] };
 
-function toRows(m: GlobalConfig['symbol_map']): Row[] {
+function toRows(m: GlobalConfig['symbol_map'] | null | undefined): Row[] {
+	if (!m) return [];
 	return Object.entries(m).map(([symbol, brokers]) => ({
 		symbol,
-		map: Object.entries(brokers).map(([broker, ticker]) => ({ broker, ticker })),
+		map: brokers ? Object.entries(brokers).map(([broker, ticker]) => ({ broker, ticker })) : [],
 	}));
 }
 


### PR DESCRIPTION
## Summary
\`GlobalConfigForm.toRows(m)\` called \`Object.entries(m)\` without a null guard. When the backend's \`/api/execution/config\` response omits the \`symbol_map\` field (the default state with no symbol mappings), \`m\` is \`undefined\` and React throws \`TypeError: Cannot convert undefined or null to object\`, unmounting the entire Execution tab into a black screen.

## Repro (before fix)
1. Fresh install with no \`symbol_map\` entries in \`execution.yaml\`
2. Open the Execution tab
3. Console: \`TypeError: Cannot convert undefined or null to object at Object.entries (<anonymous>) at toRows (...)\`
4. Tab renders blank

## Fix
Two-layer null guard in \`web/src/GlobalConfigForm.tsx:18-23\`:
- Outer: \`if (!m) return []\`
- Inner: \`brokers ? Object.entries(brokers).map(...) : []\`
- Type widened to \`GlobalConfig['symbol_map'] | null | undefined\` so the type system enforces the guard at every call site.

## Verification
- ✅ Vitest: 75/75 (existing GlobalConfigForm.test.tsx tests still pass)
- ✅ \`bun run build\`: green
- ✅ Browser repro: navigate to /, click Execution → tab renders correctly with Kill Switch / Add plugin / Max dispatched / Symbol map / Feedback table all visible. Console clean.

## Notes
- The deeper field-naming mismatch between backend (\`dedup_window_sec\`) and frontend (\`dedup_window\`) is a separate pre-existing issue not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)